### PR TITLE
Locally toggled XML escaping

### DIFF
--- a/xmlgen.el
+++ b/xmlgen.el
@@ -84,17 +84,24 @@ elements content.")
          (let ((el (car xml)))
            (unless (symbolp el)
              (error "Element must be a symbol (got '%S')." el))
-           (setq el (symbol-name el))
-           (concat "<" el (xmlgen-attr-to-string attrs)
-                   (if (> (length xml) 1)
-                       (concat ">" (mapconcat
-                                    (lambda (s) (xmlgen s el (1+ level)))
-                                    (if xmlgen-escape-elm-vals
-                                        (mapcar 'xmlgen-string-escape (cdr xml))
-                                      (cdr xml))
-                                    "")
-                               "</" el ">")
-                       "/>"))))))))
+           (if (member el '(!unescape !escape))
+               (let ((xmlgen-escape-elm-vals (if (equal '!escape el) t nil)))
+                 (mapconcat
+                  (lambda (s) (xmlgen s in-elm (1+ level)))
+                  (cdr xml)
+                  ""))
+             (progn
+                 (setq el (symbol-name el))
+                 (concat "<" el (xmlgen-attr-to-string attrs)
+                         (if (> (length xml) 1)
+                             (concat ">" (mapconcat
+                                          (lambda (s) (xmlgen s el (1+ level)))
+                                          (if xmlgen-escape-elm-vals
+                                              (mapcar 'xmlgen-string-escape (cdr xml))
+                                            (cdr xml))
+                                          "")
+                                     "</" el ">")
+                           "/>"))))))))))
 
 (defun xmlgen-string-escape (string)
   "Escape STRING for inclusion in some XML."

--- a/xmlgen.etest
+++ b/xmlgen.etest
@@ -23,6 +23,9 @@
    (equal (xmlgen '(h1 "Title")) "<h1>Title</h1>")
    (equal (xmlgen '(h1 :class "something" "hi"))
         "<h1 class=\"something\">hi</h1>")
+   (equal (xmlgen '(div (p "Escaped: &") (!unescape (p "Unescaped: &") (!escape
+                                                                        (p "& escaped")))))
+          "<div><p>Escaped: &amp;</p><p>Unescaped: &</p><p>&amp; escaped</p></div>")
    (equal (xmlgen '(p "hello" "again")) "<p>helloagain</p>")
    ("more complex"
     (equal (xmlgen


### PR DESCRIPTION
I've added (!unescape ...) and (!escape ...) forms to locally toggle XML character escaping. I'm not sure if it's something you'd find useful enough to include in mainline xmlgen (or if you'd prefer alternative syntax), but I'm using it and thought I'd send it along.

Usage:

``` lisp
(equal
 (xmlgen
  '(div
    (!unescape (p "I'll escape this myself: &amp;")
               (!escape (p "Please, escape it for me: &")))))
 "<div><p>I'll escape this myself: &amp;!</p><p>Please, escape it for me: &amp;</p></div>")
```
