### PR TITLE
Remove needless quote for byte-compile warning

### DIFF
--- a/xmlgen.el
+++ b/xmlgen.el
@@ -107,9 +107,9 @@ elements content.")
   "Escape STRING for inclusion in some XML."
   (when (stringp string)
     (mapc
-     '(lambda (e)
-       (setq string
-        (replace-regexp-in-string (car e) (cdr e) string)))
+     (lambda (e)
+      (setq string
+       (replace-regexp-in-string (car e) (cdr e) string)))
      xmlgen-escapees))
   string)
 
@@ -139,15 +139,15 @@ the plist and the plist."
         (plist '())
         (last-keyword nil))
     (mapc
-     '(lambda (item)
+     (lambda (item)
        (let ((item (pop list)))
          (cond
-           (last-keyword
-            (setq plist (append plist (list last-keyword)))
-            (setq plist (append plist (list item)))
-            (setq last-keyword nil))
-           ((keywordp item) (setq last-keyword item))
-           (t (setq nlist (append nlist (list item)))))))
+          (last-keyword
+           (setq plist (append plist (list last-keyword)))
+           (setq plist (append plist (list item)))
+           (setq last-keyword nil))
+          ((keywordp item) (setq last-keyword item))
+          (t (setq nlist (append nlist (list item)))))))
      list)
     (when last-keyword
       (error "No value to satisfy keyword '%s'"


### PR DESCRIPTION
There are following byte-compile warnings.

```
In xmlgen-string-escape:
xmlgen.el:108:18:Warning: (lambda (e) ...) quoted with ' rather than with #'

In xmlgen-extract-plist:
xmlgen.el:150:21:Warning: (lambda (item) ...) quoted with ' rather than with
    #'
```